### PR TITLE
Get rid of poll period

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ rfid.on('ready', function (version) {
   console.log('Ready to read RFID card');
 
   rfid.on('data', function(card) {
-    console.log('UID:', card.uidStr);
+    console.log('UID:', card.uid.toString('hex'));
   });
 });
 ```

--- a/examples/mifareClassic.js
+++ b/examples/mifareClassic.js
@@ -22,7 +22,7 @@ rfid.on('ready', function (version) {
   
   rfid.on('read', function(card) {
     console.log('Card found!');
-    console.log('uid:', card.uid);
+    console.log('UID:', card.uid.toString('hex'));
     console.log("Start auth #1");
 
 

--- a/examples/rfid.js
+++ b/examples/rfid.js
@@ -16,7 +16,7 @@ rfid.on('ready', function (version) {
   console.log('Ready to read RFID card');
 
   rfid.on('data', function(card) {
-    console.log('UID:', card.uidStr);
+    console.log('UID:', card.uid.toString('hex'));
   });
 });
 

--- a/index.js
+++ b/index.js
@@ -296,8 +296,7 @@ RFID.prototype._read = function (cardBaudRate, callback) {
         Card.SEL_RES = res[11];                                       // SEL_RES
         Card.idLength = res[12];                                      // NFCID Length
         Card.uid = res.slice(13, 13 + Card.idLength);                 // NFCID buffer
-        Card.uidStr = Card.uid.toString('hex');                       // NFCID string
-
+ 
         if (DEBUG) {
           console.log('Parsed card:\n', Card);
         }

--- a/test/readcard.js
+++ b/test/readcard.js
@@ -14,7 +14,7 @@ rfid.on('ready', function (version) {
   console.log('ok');
 
   rfid.on('read', function(data) {
-    console.log('# uid:', data.uidStr);
+    console.log('# uid:', data.uid.toString('hex'));
     console.log(data.uid.length == 7 ? 'ok' : data.uid.length == 4 ? 'ok' : 'not ok', '- length of returned data');
     rfid.disable();
   });


### PR DESCRIPTION
This pull request addresses issues of card read consistency as pointed out in #11. There are significant changes to the API here including a configuration object to configure either automatic or manual card reading. 
### Automatic card reading

This mode operates similar to how the existing module did. When a new data event listener is created, the module is sent a command to listen for passive targets. When one is found the target object is returned and after a timeout period has passed, the module is again told to listen for targets. The module notifies the Tessel when it has found a new target so it is no longer necessary to continually ask for a passing device. The timeout between reads can also be set in the configuration object.
### Manual card reading

Again, when a new data event listener is created, the module is sent a command to listen for passive targets. However, in this new manual mode, it is up to the user to send the command again after a card has been read. This is useful for applications in which the user would like to perform read/write operations on a card after detecting it, as the listen command will normally block these operations from being carried out as planned.

In addition there is now an exposed 'stopListening' command to take the Tessel out of the listening loop if it is no longer necessary.

So with all of these changes the Desfire card now reads 100% of the time it is places in front of the reader, however it will not read the card again until it has left the reader's field of view, and then re-enter. This problem does not show up with other types of cards, so I believe that issue has nothing to do with the module code.

Would appreciate opinions/code review on this. @johnnyman727 @tcr @ekolker @Frijol 
