### PR TITLE
Fix start.tessel.io view of example file

### DIFF
--- a/examples/rfid.js
+++ b/examples/rfid.js
@@ -8,7 +8,7 @@ then logs its UID to the console.
 *********************************************/
 
 var tessel = require('tessel');
-var rfidlib = require('../');// Replace '../' with 'rfid-pn532' in your own code
+var rfidlib = require('../'); // Replace '../' with 'rfid-pn532' in your own code
 
 var rfid = rfidlib.use(tessel.port['A']); 
 


### PR DESCRIPTION
On the start.tessel.io page (or more specifically, this page: http://start.tessel.io/modules/rfid) you can still see the text `// Replace '../' with 'rfid-pn532' in your own code`, even though the code for the start.tessel.io site tries to strip this away. The reason is that this module is lacking a space in the comment.

This PR fixes that, and I have tested it against the start.tessel.io codebase and verified the page in question will render as expected.
