### PR TITLE
lib: only run _initialize if it exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,11 @@ function RFID (hardware, options, callback) {
   self.nRST.low(); // Toggle reset every time we initialize
 
   self.i2c = new hardware.I2C(PN532_I2C_ADDRESS);
-  self.i2c._initialize();
+  
+  // This function only exists on the Tessel 1
+  if (typeof self.i2c._initialize === 'function') {
+    self.i2c._initialize();
+  }
 
   self.numListeners = 0;
   self.listening = false;


### PR DESCRIPTION
This is the first small step towards getting this module working on the T2.

I haven't had time to test it on my boards yet.