### PR TITLE
Use pin callbacks and IRQs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rfid-pn532",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Library to run the PN532 RFID Reader",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR looks bigger than it actually is but I made two changes to fix the driver for Tessel 2:

* Made `pin.write` calls provide a callback rather than assuming they work synchronously. On Tessel 2, no calls are synchronous.
* Instead of iterating every 50 seconds to check an IRQ line, I used the built-in hardware interrupts (`self.irq.once('low', function ready() {...}`). This was mostly for code cleanup rather than compatibility but it made the code much easier to get working for T2.

The test bench still passes for me (with RFID card laying on top of reader):
```
➜  rfid-pn532 git:(jon-t2-compat) t2 run test/readcard.js --lan --name Frank
INFO Looking for your Tessel...
INFO Connected to Frank.
INFO Writing project to RAM on Frank (1896.448 kB)...
INFO Deployed.
INFO Running test/readcard.js...
1..7
# Connecting to RFID card on correct port
ok 1 equal
ok 2 ok
# Basic Reading
ok 3 equal
ok 4 equal
# Change RFID Polling Period
ok 5 equal
ok 6 equal
ok 7 equal
# pass 7 7
# fail 0 7
```